### PR TITLE
Add tailscale orb to access eks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  circleci-tailscale: threecomma/circleci-tailscale@2.2.0
   aws-ecr: circleci/aws-ecr@8.1.2
   kubernetes: circleci/kubernetes@1.3
   helm: circleci/helm@1.2.0
@@ -30,6 +31,7 @@ jobs:
           name: Set ~/.kube/config so `kubectl` commands will run
           command: aws eks update-kubeconfig --region ${AWS_DEFAULT_REGION} --name << parameters.cluster-name >>
       - kubernetes/install-kubectl
+      - circleci-tailscale/connect
       - run: git clone git@github.com:papercup-ai/charts.git
       - helm/upgrade-helm-chart:
           chart: ./charts/filter-paper


### PR DESCRIPTION
This add a tailscale step before using kubectl/helm.
As part of the SOC2 compliance, we are securing our EKS Control Plane endpoint and only allowing connection coming from the same VPC
CircleCI needs access to be able to deploy and communicate with the kubernetes api server.
We deployed a tailscale subnet router that acts as a VPN Gateway so that any tailscale client can reach our VPC IPs through that router.

This PR:
- Adds the tailscale orb
- Adds a step after kubernetes/install-kubectl that configure tailscale so the remaining steps use the subnet router.
